### PR TITLE
Complete EC2 Hosts for SSH

### DIFF
--- a/completions/ssh
+++ b/completions/ssh
@@ -112,6 +112,29 @@ _ssh_suboption_check()
     return 1
 }
 
+_ec2_hosts()
+{
+    # Cache ec2 host names for 1 minute for speed
+    local cache_file="${HOME}/.ec2_node_names"
+
+    # Refresh the cache if:
+    # - There is no cache
+    # - It doesn't contain the search string
+    # - It's more than 5 minutes old
+    if [ ! -f "${cache_file}" ] || \
+        ! grep -q ${1} "${cache_file}" || \
+        test `find "${cache_file}" -mmin +5`; then
+        aws ec2 describe-instances | \
+            grep 'TAGS\tName' | \
+            awk '{print $3}' > "${cache_file}"
+    fi
+
+    COMPREPLY+=( $( compgen -W \
+        "$(cat "${cache_file}")" -- "${1}" ) )
+
+    return 0
+}
+
 _ssh()
 {
     local cur prev words cword
@@ -184,6 +207,7 @@ _ssh()
             shift
         done
         _known_hosts_real -a -F "$configfile" "$cur"
+        _ec2_hosts "$cur"
         if [[ $cword -ne 1 ]]; then
             compopt -o filenames
             COMPREPLY+=( $( compgen -c -- "$cur" ) )

--- a/completions/ssh
+++ b/completions/ssh
@@ -207,7 +207,7 @@ _ssh()
             shift
         done
         _known_hosts_real -a -F "$configfile" "$cur"
-        if [ ${AWS_ACCESS_KEY} ] && [ ${AWS_SECRET_KEY} ]; then
+        if [ ${AWS_ACCESS_KEY} ] && [ ${AWS_SECRET_KEY} ] && [ $(which aws) ]; then
             _ec2_hosts "$cur"
         fi
         if [[ $cword -ne 1 ]]; then

--- a/completions/ssh
+++ b/completions/ssh
@@ -135,7 +135,7 @@ _ec2_hosts()
     # - It's more than 5 minutes old
     if [ ! -f "${cache_file}" ] || \
         ! grep -q ${1} "${cache_file}" || \
-        test `find "${cache_file}" -mmin +5`; then
+        test `find "${cache_file}" -mmin +1440`; then
         aws ec2 describe-instances | \
             grep 'TAGS\tName' | \
             awk '{print $3}' > "${cache_file}"

--- a/completions/ssh
+++ b/completions/ssh
@@ -132,6 +132,11 @@ _ec2_hosts()
     COMPREPLY+=( $( compgen -W \
         "$(cat "${cache_file}")" -- "${1}" ) )
 
+    # Refresh the cache in the background every time
+    aws ec2 describe-instances | \
+        grep 'TAGS\tName' | \
+        awk '{print $3}' > "${cache_file}" &
+
     return 0
 }
 

--- a/completions/ssh
+++ b/completions/ssh
@@ -112,6 +112,18 @@ _ssh_suboption_check()
     return 1
 }
 
+_refresh_ec2_hosts_cache()
+{
+    local hosts
+    local cache_file="${1}"
+
+    hosts=`aws ec2 describe-instances | grep 'TAGS\tName' | awk '{print $3}'`
+
+    if [ -n "${hosts}" ]; then
+        echo ${hosts} > "${cache_file}"
+    fi
+}
+
 _ec2_hosts()
 {
     # Cache ec2 host names for 1 minute for speed
@@ -134,9 +146,7 @@ _ec2_hosts()
 
     # Refresh the cache in the background every time (Run in a subshell to
     # suppress PID output)
-    (aws ec2 describe-instances | \
-        grep 'TAGS\tName' | \
-        awk '{print $3}' > "${cache_file}" &)
+    (_refresh_ec2_hosts_cache "${cache_file}" &)
 
     return 0
 }

--- a/completions/ssh
+++ b/completions/ssh
@@ -132,10 +132,11 @@ _ec2_hosts()
     COMPREPLY+=( $( compgen -W \
         "$(cat "${cache_file}")" -- "${1}" ) )
 
-    # Refresh the cache in the background every time
-    aws ec2 describe-instances | \
+    # Refresh the cache in the background every time (Run in a subshell to
+    # suppress PID output)
+    (aws ec2 describe-instances | \
         grep 'TAGS\tName' | \
-        awk '{print $3}' > "${cache_file}" &
+        awk '{print $3}' > "${cache_file}" &)
 
     return 0
 }

--- a/completions/ssh
+++ b/completions/ssh
@@ -207,7 +207,9 @@ _ssh()
             shift
         done
         _known_hosts_real -a -F "$configfile" "$cur"
-        _ec2_hosts "$cur"
+        if [ ${AWS_ACCESS_KEY} ] && [ ${AWS_SECRET_KEY} ]; then
+            _ec2_hosts "$cur"
+        fi
         if [[ $cword -ne 1 ]]; then
             compopt -o filenames
             COMPREPLY+=( $( compgen -c -- "$cur" ) )


### PR DESCRIPTION
Not sure if there's any interest in this in the broader project but we needed it internally so I figured I might as well push it up stream:

This function uses `aws ec2 describe-instances` to do command completion against instance name tags in the user's EC2 cluster, provided that `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` are defined.
